### PR TITLE
Fix `this._param_reader is undefined` in Firefox

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -6,6 +6,7 @@ function log(str) {
 }
 
 const ctx = new AudioContext();
+ctx.suspend();
 var frequency = 440,
     phase = 0.0,
     sine = new Float32Array(128);

--- a/example/processor.js
+++ b/example/processor.js
@@ -5,22 +5,15 @@ class Processor extends AudioWorkletProcessor {
     return [];
   }
 
-  constructor() {
-    super();
+  constructor(options) {
+    super(options);
     this.interleaved = new Float32Array(128);
     this.amp = 1.0;
     this.o = { index: 0, value: 0 };
-    this.port.onmessage = e => {
-      this._size = 128;
-      if (e.data.type === "recv-audio-queue") {
-        this._audio_reader = new AudioReader(new RingBuffer(e.data.data, Float32Array));
-      } else if (e.data.type === "recv-param-queue") {
-        this._param_reader = new ParameterReader(new RingBuffer(e.data.data, Uint8Array));
-      } else {
-        throw "unexpected.";
-      }
-    };
-  }
+    const { audioQueue, paramQueue } = options.processorOptions;
+    this._audio_reader = new AudioReader(new RingBuffer(audioQueue, Float32Array));
+    this._param_reader = new ParameterReader(new RingBuffer(paramQueue, Uint8Array));
+}
 
   process(inputs, outputs, parameters) {
     // Get any param changes


### PR DESCRIPTION
In Firefox it seems audio starts processing without an explicit user action, which breaks some assumptions elsewhere in the app:
1. the `SharedArrayBuffer`s used for the parameter and audio queues are currently passed to the `Processor` asynchronously over the message port, which means it isn't valid on construction. So, there is a race - if audio starts before these messages are received, the ring buffers are not initialised when `process` is called
2. the "start" button expects to toggle the running state on and off, so if the `AudioContext` is already running, clicking "Start" doesn't update the text of the button to "Stop"

This PR suspends the `AudioContext` immediately after construction, which is all that is really needed to fix this, but also uses the `AudioWorkletNodeOptions` to pass the `SharedArrayBuffer`s to the `Processor` on construction.